### PR TITLE
Install aliyun cli proactively and upgrade paramiko module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ MarkupSafe==1.1.1
 ntlm-auth==1.1.0
 oss2==2.15.0
 packaging==21.0
-paramiko==2.7.1
+paramiko==2.11.0
 ply==3.11
 pyasn1==0.4.8
 pycparser==2.19

--- a/storage/modify_disk_perflevel.sh
+++ b/storage/modify_disk_perflevel.sh
@@ -3,9 +3,11 @@
 # Set performance level to PL3 by default
 perf_level=PL3
 
-which aliyun > /dev/null || {
-    echo "ERROR: Please make sure aliyun CLI exists in your env!"
-    exit 1
+which aliyun &> /dev/null || {
+    curl -s -kL  https://aliyuncli.alicdn.com/aliyun-cli-linux-latest-amd64.tgz -o /tmp/aliyun-cli-linux-latest-amd64.tgz
+    tar zxf /tmp/aliyun-cli-linux-latest-amd64.tgz
+    mv -f aliyun /usr/local/bin
+    rm -f /tmp/aliyun-cli-linux-latest-amd64.tgz
 }
  
 region=$(grep alicloud_region ansible_vars.yml | awk '{print $2}')


### PR DESCRIPTION
1. Install aliyun cli command proactively (in order to modify disk performance level)
2. Upgrade paramiko module to avoid the following error when running storage performance test :
   UNREACHABLE! => {'changed': false, 'msg': 'encountered RSA key, expected OPENSSH key', 'unreachable': true}